### PR TITLE
W-XXX: Fix spaces on external resource test

### DIFF
--- a/src/test/java/org/mule/tools/apikit/MainAppScaffolderApiSyncTest.java
+++ b/src/test/java/org/mule/tools/apikit/MainAppScaffolderApiSyncTest.java
@@ -128,22 +128,21 @@ public class MainAppScaffolderApiSyncTest extends AbstractScaffolderTestCase {
 
   @Test
   public void libraryReferenceToRoot() throws Exception {
-    final String rootRaml = "test api";
     final String ramlFolder = "src/test/resources/api-sync/library-reference-to-root/root/";
     final String libraryFolder = "src/test/resources/api-sync/library-reference-to-root/library/";
     final List<String> libraryFiles = Arrays.asList("library.raml", "reused-fragment.raml");
 
     final String exchangeJsonResourceURL = ROOT_RAML_RESOURCE_URL + "exchange.json";
-    final String rootRamlResourceURL = ROOT_RAML_RESOURCE_URL + rootRaml + ".raml";
+    final String rootRamlResourceURL = ROOT_RAML_RESOURCE_URL + "test%20api.raml";
 
-    mockScaffolderResourceLoader(exchangeJsonResourceURL, ramlFolder, rootRaml + ".json");
-    mockScaffolderResourceLoader(rootRamlResourceURL, ramlFolder, rootRaml + ".raml");
+    mockScaffolderResourceLoader(exchangeJsonResourceURL, ramlFolder, "test api.json");
+    mockScaffolderResourceLoader(rootRamlResourceURL, ramlFolder, "test api.raml");
 
     for (String rootRamlFile : libraryFiles) {
       mockScaffolderResourceLoader(DEPENDENCIES_RESOURCE_URL + rootRamlFile, libraryFolder, rootRamlFile);
     }
 
-    ApiReference apiReference = ApiReference.create(ROOT_RAML_RESOURCE_URL + rootRaml + ".raml", scaffolderResourceLoaderMock);
+    ApiReference apiReference = ApiReference.create(rootRamlResourceURL, scaffolderResourceLoaderMock);
     ParseResult parseResult = new ParserService().parse(apiReference);
     assertTrue(parseResult.success());
 

--- a/src/test/resources/api-sync/library-reference-to-root/expected.xml
+++ b/src/test/resources/api-sync/library-reference-to-root/expected.xml
@@ -3,7 +3,7 @@
     <http:listener-config name="test-api-httpListenerConfig">
         <http:listener-connection host="0.0.0.0" port="8081" />
     </http:listener-config>
-    <apikit:config name="test-api-config" api="resource::com.mycompany:raml-api:1.0.0:raml:zip:test api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
+    <apikit:config name="test-api-config" api="resource::com.mycompany:raml-api:1.0.0:raml:zip:test%20api.raml" outboundHeadersMapName="outboundHeaders" httpStatusVarName="httpStatus" />
     <flow name="test-api-main">
         <http:listener config-ref="test-api-httpListenerConfig" path="/api/*">
             <http:response statusCode="#[vars.httpStatus default 200]">


### PR DESCRIPTION
This PR changes a broken test for the new behaviour introduced on W-11687519. See https://github.com/mulesoft/apikit-rest-parser-wrapper/pull/356 for more info.