### PR TITLE
W-13577593: update dependencies for java 17 support

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -24,11 +24,12 @@
         <gson.version>2.9.1</gson.version>
 
         <xmlunit.version>2.9.1</xmlunit.version>
-        <jacoco.version>0.8.5</jacoco.version>
         <allureJunitVersion>2.18.1</allureJunitVersion>
         <allureReportVersion>2.3.4</allureReportVersion>
         <allure.maven.plugin.version>2.10.0</allure.maven.plugin.version>
 
+        <jacoco.version>0.8.10</jacoco.version>
+        <mockito-junit-jupiter.version>4.11.0</mockito-junit-jupiter.version>
     </properties>
 
     <dependencies>
@@ -110,8 +111,8 @@
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
-            <version>1.10.19</version>
+            <artifactId>mockito-junit-jupiter</artifactId>
+            <version>${mockito-junit-jupiter.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/src/test/java/org/mule/tools/apikit/GenerationModelTest.java
+++ b/src/test/java/org/mule/tools/apikit/GenerationModelTest.java
@@ -9,7 +9,7 @@ package org.mule.tools.apikit;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.apikit.model.ActionType.DELETE;

--- a/src/test/java/org/mule/tools/apikit/MuleConfigTest.java
+++ b/src/test/java/org/mule/tools/apikit/MuleConfigTest.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.anyString;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.mule.apikit.model.ActionType.GET;

--- a/src/test/java/org/mule/tools/apikit/output/MuleConfigGeneratorTest.java
+++ b/src/test/java/org/mule/tools/apikit/output/MuleConfigGeneratorTest.java
@@ -29,8 +29,9 @@ import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.any;
-import static org.mockito.Matchers.anyString;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.doCallRealMethod;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;


### PR DESCRIPTION
Jacoco version -> 0.8.10
Mockito version -> 4.11.0 (this support both java 8 & java 17, mockito 5 no longer supports java 8) 
